### PR TITLE
changes to clock configuration

### DIFF
--- a/root/.config/xfce4/panel/xfce4-orageclock-plugin-1.rc
+++ b/root/.config/xfce4/panel/xfce4-orageclock-plugin-1.rc
@@ -1,15 +1,13 @@
-show_frame=true
-fg_set=true
-bg_set=true
+show_frame=false
+fg_set=false
+bg_set=false
 timezone=
 width_set=false
 height_set=false
 lines_vertically=true
 rotation=0
 data0=%H:%M
-font0=Droid Sans 10
+font0=Droid Sans Bold 8
 tooltip=%c
 hib_timing=false
-fg=65535R 65535G 65535B
-bg=22616R 13107G 11051B
 

--- a/skel/.config/xfce4/panel/xfce4-orageclock-plugin-1.rc
+++ b/skel/.config/xfce4/panel/xfce4-orageclock-plugin-1.rc
@@ -1,15 +1,13 @@
-show_frame=true
-fg_set=true
-bg_set=true
+show_frame=false
+fg_set=false
+bg_set=false
 timezone=
 width_set=false
 height_set=false
 lines_vertically=true
 rotation=0
 data0=%H:%M
-font0=Droid Sans 10
+font0=Droid Sans Bold 8
 tooltip=%c
 hib_timing=false
-fg=65535R 65535G 65535B
-bg=22616R 13107G 11051B
 

--- a/vertical/panel/xfce4-orageclock-plugin-1.rc
+++ b/vertical/panel/xfce4-orageclock-plugin-1.rc
@@ -1,15 +1,14 @@
-show_frame=true
-fg_set=true
-bg_set=true
+show_frame=false
+fg_set=false
+bg_set=false
 timezone=
 width_set=false
 height_set=false
 lines_vertically=true
 rotation=0
 data0=%H:%M
-font0=Droid Sans 10
+font0=Droid Sans Bold 8
 tooltip=%c
 hib_timing=false
-fg=65535R 65535G 65535B
-bg=22616R 13107G 11051B
+
 


### PR DESCRIPTION
effort to make clock text visible on all screens.  type face reduced to 8, weight increased to bold.  background colors removed.

note:  original clock configuration remains in the horizontal panel folder, which is not used in mx16.  so easy to revert if necessary.
